### PR TITLE
Fix websocket request formatting

### DIFF
--- a/src/stream_api/ws.rs
+++ b/src/stream_api/ws.rs
@@ -287,7 +287,7 @@ impl TransactionsStream {
                     if ops.is_empty() {
                         ac_op.account
                     } else {
-                        format!("{};{}", ac_op.account, ops.join(","))
+                        format!("{};operations={}", ac_op.account, ops.join(","))
                     }
                 })
                 .collect();


### PR DESCRIPTION
# Bug
If `operations` field is set in `transaction_stream` in websocket client

```rust
let mut stream = ws.transactions_stream(Some(vec![AccountOperations {
    account: "0QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkT".to_string(),
    operations: Some(vec!["0x0f8a7ea5".to_string()]),
}]));
```

There will be an errors in logs:
```log
init connection response: failed to process '0QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkT;0x0f8a7ea5' account: invalid format
```

# Reason

According [TonApi](https://docs.tonconsole.com/tonapi/streaming-api#subscribe_account-method) request have to be following format:
```
0QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkT;operations=0x0f8a7ea5
```