### PR TITLE
Expose REST API modules

### DIFF
--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -1,7 +1,7 @@
-mod base;
-mod error;
-mod models;
-mod v2;
-mod query_params;
+pub mod base;
+pub mod error;
+pub mod models;
+pub mod v2;
+pub mod query_params;
 
 pub use v2::RestApiClientV2;

--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -1,7 +1,8 @@
-pub mod base;
-pub mod error;
+mod base;
+mod error;
 pub mod models;
-pub mod v2;
-pub mod query_params;
+mod v2;
+mod query_params;
 
 pub use v2::RestApiClientV2;
+pub use error::TonApiError;


### PR DESCRIPTION
**PR summary**

This modification make REST API modules public. Without this changes it is impossible to use any internal types. E.g. it is impossible to use `Transaction` type as function argument, because it cannot be imported.
